### PR TITLE
Add language code to page

### DIFF
--- a/themes/solar-theme-hugo/layouts/_default/baseof.html
+++ b/themes/solar-theme-hugo/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.LanguageCode | default site.Language.Lang }}">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width">


### PR DESCRIPTION
Hello — just proposing a change to add the language code to the `html` element — this will improve Pagefind's indexing to be French-aware (and give you a translated UI too) 🙂